### PR TITLE
Enable Support for active support logging as well

### DIFF
--- a/lib/minitest-logger.rb
+++ b/lib/minitest-logger.rb
@@ -144,14 +144,14 @@ with this parameter.
           log.outputters << outputter = Log4r::StringOutputter.new('stringoutputter') 
           outputter.level = level if level
           outputter.formatter = formatter if formatter
-        when 'Logger'
+        when 'Logger', 'ActiveSupport::Logger'
           log.catch_messages(level)
         end
       yield #call block to get messages
       case log.class.to_s
         when 'Log4r::Logger'
           logtext = outputter.flush
-        when 'Logger'
+        when 'Logger', 'ActiveSupport::Logger'
           logtext = log.catch_messages_stop()
         end      
       return logtext


### PR DESCRIPTION
since we are adding sidekiq jobs and those dont return anything
so we have to verify using the logs. Mintest-logger helps with that but it only supports Logger and log4r.  It wasnt working with juulogi's Rails logger as that is based on activesupport logger. Since Active Support is also a sub class of Logger it works similar
to it and works with the same code.